### PR TITLE
Do full check out, fixes build version counting number of commits

### DIFF
--- a/.github/workflows/publish-jar.yml
+++ b/.github/workflows/publish-jar.yml
@@ -11,6 +11,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - uses: actions/setup-java@v3
         with:
           java-version: '11'


### PR DESCRIPTION
By default there is a shallow checkout. In this default situation, the count of commit is always 1, which makes our build number always '1' instead of incrementing.