### PR TITLE
Build: Remove publish credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,6 @@ publishing {
         maven {
             name = 'GitHubPackages'
             url = uri('https://maven.pkg.github.com/triplea-game/maps-client')
-            credentials {
-                username = System.getenv('GITHUB_ACTOR')
-                password = System.getenv('GITHUB_TOKEN')
-            }
         }
     }
     publications {


### PR DESCRIPTION
Only github actions should be executing our publish actions. Github actions do not need credentials when publishing.