### PR TITLE
Fix build & use Jackson JSON encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-<a href="https://codeclimate.com/github/triplea-game/maps-client/maintainability"><img src="https://api.codeclimate.com/v1/badges/fc0b1761a20241f63f30/maintainability" /></a>
-
 # maps-client
+
 HTTP client for maps-server
 
-Maps server provides endpoints to:
-- list maps
-- view & update map tags
+Provides two client interfaces:
+1. MapsClient
+    - no authentication needed
+    - can use to list maps
+2. MapsTagAdminClient
+    - requires authenticatoion
+    - update map tags

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
     mavenCentral()
 }
 
+shadowJar {
+    classifier = ''
+}
+
 publishing {
     repositories {
         maven {
@@ -75,19 +79,15 @@ pmd {
 
 
 dependencies {
+    implementation 'ch.qos.logback:logback-classic:1.4.5'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'io.github.openfeign:feign-core:12.1'
-    implementation 'io.github.openfeign:feign-gson:12.1'
+    implementation 'com.netflix.feign:feign-jackson:8.18.0'
 
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.1'
     testImplementation 'com.github.tomakehurst:wiremock:2.27.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     testImplementation 'ru.lanwen.wiremock:wiremock-junit5:1.3.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
-    testImplementation 'org.slf4j:slf4j-simple:2.0.4'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
 }

--- a/src/main/java/org/triplea/http/client/maps/listing/MapDownloadItem.java
+++ b/src/main/java/org/triplea/http/client/maps/listing/MapDownloadItem.java
@@ -4,34 +4,32 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents a map that can be downloaded. This data object contains information on how to render a
  * preview and description of the map, as well as the needed URLs to download the map itself.
  */
+@Data
 @Builder
 @AllArgsConstructor
-@Getter
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 public class MapDownloadItem {
   /** URL where the map can be downloaded. */
-  @Nonnull private final String downloadUrl;
+  @Nonnull private String downloadUrl;
   /** URL of the preview image of the map. */
-  @Nonnull private final String previewImageUrl;
+  @Nonnull private String previewImageUrl;
 
-  @Nonnull private final String mapName;
-  @Nonnull private final Long lastCommitDateEpochMilli;
+  @Nonnull private String mapName;
+  @Nonnull private Long lastCommitDateEpochMilli;
   /** HTML description of the map. */
-  @Nonnull private final String description;
+  @Nonnull private String description;
 
   /** Additional meta data about the map, eg: categories, rating, etc... */
-  private final List<MapTag> mapTags;
+  private List<MapTag> mapTags;
 
-  @Nonnull private final Long downloadSizeInBytes;
+  @Nonnull private Long downloadSizeInBytes;
 
   /**
    * Finds a tag by name and returns its corresponding value. If the tag is not found or has a null

--- a/src/main/java/org/triplea/http/client/maps/listing/MapTag.java
+++ b/src/main/java/org/triplea/http/client/maps/listing/MapTag.java
@@ -1,18 +1,20 @@
 package org.triplea.http.client.maps.listing;
 
 import java.util.Optional;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 'Map Tag' data as attached to a specific map. A map will contain a set of 'MapTag' data items.
  * This data represents the current value of a specific tag and the necessary information to display
  * a tags value to user.
  */
-@Value
+@Data
 @Builder
-@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
 public class MapTag {
   /** The human readable name of the tag */
   String name;

--- a/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -3,8 +3,8 @@ package org.triplea.http.client.maps.listing;
 import feign.Feign;
 import feign.FeignException;
 import feign.RequestLine;
-import feign.gson.GsonDecoder;
-import feign.gson.GsonEncoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 import java.net.URI;
 import java.util.List;
 
@@ -16,8 +16,8 @@ public interface MapsClient {
 
   static MapsClient newClient(URI mapsServerUri) {
     return Feign.builder()
-        .encoder(new GsonEncoder())
-        .decoder(new GsonDecoder())
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
         .requestInterceptor(
             requestTemplate -> {
               requestTemplate.header("Content-Type", "application/json");

--- a/src/main/java/org/triplea/http/client/maps/tag/admin/MapTagAdminClient.java
+++ b/src/main/java/org/triplea/http/client/maps/tag/admin/MapTagAdminClient.java
@@ -2,8 +2,8 @@ package org.triplea.http.client.maps.tag.admin;
 
 import feign.Feign;
 import feign.RequestLine;
-import feign.gson.GsonDecoder;
-import feign.gson.GsonEncoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 import java.net.URI;
 import java.util.List;
 
@@ -14,8 +14,8 @@ public interface MapTagAdminClient {
 
   static MapTagAdminClient newClient(final URI mapsServerUri, final String apiKey) {
     return Feign.builder()
-        .encoder(new GsonEncoder())
-        .decoder(new GsonDecoder())
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
         .requestInterceptor(
             requestTemplate -> {
               requestTemplate.header("Authorization", "Bearer " + apiKey);

--- a/src/main/java/org/triplea/http/client/maps/tag/admin/MapTagMetaData.java
+++ b/src/main/java/org/triplea/http/client/maps/tag/admin/MapTagMetaData.java
@@ -2,15 +2,19 @@ package org.triplea.http.client.maps.tag.admin;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Data about a map tag useful for moderator toolbox. Data drives the ability for moderators to be
  * able to change map tag information.
  */
 @Builder
-@Value
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MapTagMetaData {
   @Nonnull String tagName;
   @Nonnull Integer displayOrder;

--- a/src/main/java/org/triplea/http/client/maps/tag/admin/UpdateMapTagRequest.java
+++ b/src/main/java/org/triplea/http/client/maps/tag/admin/UpdateMapTagRequest.java
@@ -3,15 +3,13 @@ package org.triplea.http.client.maps.tag.admin;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@EqualsAndHashCode
 public class UpdateMapTagRequest {
   private String mapName;
   private String tagName;

--- a/src/main/java/org/triplea/http/client/maps/tag/admin/UpdateMapTagResponse.java
+++ b/src/main/java/org/triplea/http/client/maps/tag/admin/UpdateMapTagResponse.java
@@ -1,11 +1,15 @@
 package org.triplea.http.client.maps.tag.admin;
 
 import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
 @Builder
-@Value
+@AllArgsConstructor
+@NoArgsConstructor
 public class UpdateMapTagResponse {
   boolean success;
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %logger{36} %-5level: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
- To keep the client consistent with the github-client, switch JSON encoder to Jackson
- Config fix for build to strip '-all' on shadow jar name (with -all, it would not be found properly by depenendent projects)